### PR TITLE
Feature/disable-vitest-globals

### DIFF
--- a/__tests__/mocks/console.mock.ts
+++ b/__tests__/mocks/console.mock.ts
@@ -1,4 +1,4 @@
-import type { MockInstance } from 'vitest';
+import { vi, type MockInstance } from 'vitest';
 
 type LogHandler = typeof console.log;
 

--- a/__tests__/mocks/fs.mock.ts
+++ b/__tests__/mocks/fs.mock.ts
@@ -1,8 +1,8 @@
 import fsp from 'node:fs/promises';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
-import type { MockInstance } from 'vitest';
 import { ROOT_PATH } from '#src/services/root.service.ts';
+import { vi, type MockInstance } from 'vitest';
 
 vi.mock('node:fs/promises');
 

--- a/__tests__/mocks/loading.mock.ts
+++ b/__tests__/mocks/loading.mock.ts
@@ -1,5 +1,5 @@
 import * as ora from 'ora';
-import type { MockInstance } from 'vitest';
+import { vi, type MockInstance } from 'vitest';
 
 vi.mock('ora');
 

--- a/__tests__/mocks/prompt.mock.ts
+++ b/__tests__/mocks/prompt.mock.ts
@@ -1,5 +1,5 @@
 import inquirer from 'inquirer';
-import type { MockInstance } from 'vitest';
+import { vi, type MockInstance } from 'vitest';
 
 vi.mock('inquirer');
 

--- a/__tests__/mocks/terminal.mock.ts
+++ b/__tests__/mocks/terminal.mock.ts
@@ -1,5 +1,5 @@
 import * as execa from 'execa';
-import type { MockInstance } from 'vitest';
+import { vi, type MockInstance } from 'vitest';
 
 vi.mock('execa');
 

--- a/__tests__/setup-test-context.ts
+++ b/__tests__/setup-test-context.ts
@@ -5,6 +5,7 @@ import { Loading } from './mocks/loading.mock.ts';
 import { PresetStateMock } from './mocks/preset-state.mock.ts';
 import { Prompt } from './mocks/prompt.mock.ts';
 import { Terminal } from './mocks/terminal.mock.ts';
+import { afterEach, beforeEach } from 'vitest';
 
 export const consoleMock = new ConsoleMock();
 export const presetState = new PresetStateMock();

--- a/__tests__/unit/categories/index.spec.ts
+++ b/__tests__/unit/categories/index.spec.ts
@@ -1,4 +1,5 @@
 import categories from '#src/categories/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('index', () => {
   describe('categories', () => {

--- a/__tests__/unit/categories/js/build-workflow/build-workflow.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/build-workflow/build-workflow.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem } from '#__tests__/setup-test-context.ts';
 import { buildWorkflow } from '#src/categories/js/build-workflow/build-workflow.entrypoint.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('build-workflow.entrypoint', () => {
   describe('buildWorkflow', () => {

--- a/__tests__/unit/categories/js/build-workflow/config/index.spec.ts
+++ b/__tests__/unit/categories/js/build-workflow/config/index.spec.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '#src/categories/js/build-workflow/config/index.ts';
 import { expectGithubWorkflow } from '#__tests__/utils/github.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('build-workflow/config', () => {
   it('returns the build workflow content', () => {

--- a/__tests__/unit/categories/js/codecov-workflow/codecov-workflow.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/codecov-workflow/codecov-workflow.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem } from '#__tests__/setup-test-context.ts';
 import { codecovWorkflow } from '#src/categories/js/codecov-workflow/codecov-workflow.entrypoint.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('codecov-workflow.entrypoint', () => {
   describe('codecovWorkflow', () => {

--- a/__tests__/unit/categories/js/codecov-workflow/config/index.spec.ts
+++ b/__tests__/unit/categories/js/codecov-workflow/config/index.spec.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '#src/categories/js/codecov-workflow/config/index.ts';
 import { expectGithubWorkflow } from '#__tests__/utils/github.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('codecov-workflow/config', () => {
   it('returns the codecov workflow content', () => {

--- a/__tests__/unit/categories/js/commitlint/commitlint.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/commitlint/commitlint.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { commitlint } from '#src/categories/js/commitlint/commitlint.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('commitlint.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/commitlint/commitlint.service.spec.ts
+++ b/__tests__/unit/categories/js/commitlint/commitlint.service.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
 import { huskyIntegration } from '#src/categories/js/commitlint/commitlint.service.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('commitlint.service', () => {
   describe('huskyIntegration', () => {

--- a/__tests__/unit/categories/js/commitlint/config/index.spec.ts
+++ b/__tests__/unit/categories/js/commitlint/config/index.spec.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '#src/categories/js/commitlint/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('commitlint/config', () => {
   it('returns conventional commitlint packages and config', () => {

--- a/__tests__/unit/categories/js/dependabot/config/index.spec.ts
+++ b/__tests__/unit/categories/js/dependabot/config/index.spec.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '#src/categories/js/dependabot/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('dependabot/config', () => {
   it('returns the expected dependabot update schedule', () => {

--- a/__tests__/unit/categories/js/dependabot/dependabot.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/dependabot/dependabot.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem } from '#__tests__/setup-test-context.ts';
 import { dependabot } from '#src/categories/js/dependabot/dependabot.entrypoint.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('dependabot.entrypoint', () => {
   describe('dependabot', () => {

--- a/__tests__/unit/categories/js/docker/config/index.spec.ts
+++ b/__tests__/unit/categories/js/docker/config/index.spec.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '#src/categories/js/docker/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('docker/config', () => {
   it('returns Dockerfile content for the requested node version', () => {

--- a/__tests__/unit/categories/js/docker/docker.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/docker/docker.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { docker } from '#src/categories/js/docker/docker.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('docker.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/eslint/config/index.spec.ts
+++ b/__tests__/unit/categories/js/eslint/config/index.spec.ts
@@ -1,5 +1,6 @@
 import { presetState } from '#__tests__/setup-test-context.ts';
 import { getConfig } from '#src/categories/js/eslint/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('eslint/config', () => {
   it('returns the default javascript eslint config', () => {

--- a/__tests__/unit/categories/js/eslint/eslint.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/eslint/eslint.entrypoint.spec.ts
@@ -1,6 +1,7 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { createConfig } from '#__tests__/utils/eslint.utils.ts';
 import { buildConfig, eslint } from '#src/categories/js/eslint/eslint.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('eslint.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/eslint/eslint.service.spec.ts
+++ b/__tests__/unit/categories/js/eslint/eslint.service.spec.ts
@@ -1,6 +1,7 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
 import { createConfig } from '#__tests__/utils/eslint.utils.ts';
 import { prettierMutation, jestMutation, isEslintInstalled } from '#src/categories/js/eslint/eslint.service.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('eslint.service', () => {
   describe('prettierMutation', () => {

--- a/__tests__/unit/categories/js/husky/husky.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/husky/husky.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { husky } from '#src/categories/js/husky/husky.entrypoint.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('husky.entrypoint', () => {
   describe('husky', () => {

--- a/__tests__/unit/categories/js/husky/husky.service.spec.ts
+++ b/__tests__/unit/categories/js/husky/husky.service.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
 import { addHook, isHuskyInstalled } from '#src/categories/js/husky/husky.service.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('husky.service', () => {
   describe('addHook', () => {

--- a/__tests__/unit/categories/js/index.spec.ts
+++ b/__tests__/unit/categories/js/index.spec.ts
@@ -1,5 +1,6 @@
 import js from '#src/categories/js/index.ts';
 import { jsCategory } from '#src/services/state.service.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('index', () => {
   describe('js', () => {

--- a/__tests__/unit/categories/js/jest/config/index.spec.ts
+++ b/__tests__/unit/categories/js/jest/config/index.spec.ts
@@ -1,6 +1,7 @@
 import { presetState } from '#__tests__/setup-test-context.ts';
 import { parseCjsModule } from '#__tests__/utils/cjs.utils.ts';
 import { getConfig } from '#src/categories/js/jest/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 const scripts = [
   { name: 'test', script: 'jest' },

--- a/__tests__/unit/categories/js/jest/jest.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/jest/jest.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { jestEntrypoint } from '#src/categories/js/jest/jest.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('jest.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/jest/jest.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/jest/jest.entrypoint.spec.ts
@@ -1,5 +1,5 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
-import { jestEntrypoint } from '#src/categories/js/jest/jest.entrypoint.ts';
+import { jest } from '#src/categories/js/jest/jest.entrypoint.ts';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('jest.entrypoint', () => {
@@ -9,7 +9,7 @@ describe('jest.entrypoint', () => {
 
   describe('jest', () => {
     it('installs jest dependencies and writes the default config file', async () => {
-      await jestEntrypoint();
+      await jest();
 
       expect(terminal.getCommands()).toEqual([['npm', ['i', '-D', 'jest', '@types/jest']]]);
       expect(fileSystem.readFile('jest.config.cjs')).toBe(
@@ -29,7 +29,7 @@ describe('jest.entrypoint', () => {
     it('adds test scripts to package.json', async () => {
       fileSystem.seed({ packageJson: { scripts: { lint: 'eslint "**/*.js"' } } });
 
-      await jestEntrypoint();
+      await jest();
 
       expect(fileSystem.readJson('package.json')).toEqual({
         scripts: {

--- a/__tests__/unit/categories/js/jest/jest.service.spec.ts
+++ b/__tests__/unit/categories/js/jest/jest.service.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
 import { isJestInstalled } from '#src/categories/js/jest/jest.service.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('jest.service', () => {
   describe('isJestInstalled', () => {

--- a/__tests__/unit/categories/js/lint-staged/config/index.spec.ts
+++ b/__tests__/unit/categories/js/lint-staged/config/index.spec.ts
@@ -1,6 +1,7 @@
 import { presetState, installationState } from '#__tests__/setup-test-context.ts';
 import { getConfig } from '#src/categories/js/lint-staged/config/index.ts';
 import type { LintStagedConfig } from '#src/categories/js/lint-staged/config/config.interface.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('lint-staged/config', () => {
   const getMutatedConfig = async () => {

--- a/__tests__/unit/categories/js/lint-staged/lint-staged.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/lint-staged/lint-staged.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { lintStaged } from '#src/categories/js/lint-staged/lint-staged.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('lint-staged.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/lint-staged/lint-staged.service.spec.ts
+++ b/__tests__/unit/categories/js/lint-staged/lint-staged.service.spec.ts
@@ -1,4 +1,5 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
+import { describe, expect, it } from 'vitest';
 import {
   addOptionToLintStagedConfig,
   huskyIntegration,

--- a/__tests__/unit/categories/js/prettier/config/index.spec.ts
+++ b/__tests__/unit/categories/js/prettier/config/index.spec.ts
@@ -1,5 +1,6 @@
 import { presetState } from '#__tests__/setup-test-context.ts';
 import { getConfig } from '#src/categories/js/prettier/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('prettier/config', () => {
   it('returns the default prettier config for every js variant', () => {

--- a/__tests__/unit/categories/js/prettier/prettier.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/prettier/prettier.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { prettier } from '#src/categories/js/prettier/prettier.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('prettier.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/prettier/prettier.service.spec.ts
+++ b/__tests__/unit/categories/js/prettier/prettier.service.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
 import { formatJavascript, isPrettierInstalled } from '#src/categories/js/prettier/prettier.service.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('prettier.service', () => {
   describe('formatJavascript', () => {

--- a/__tests__/unit/categories/js/release-workflow/config/index.spec.ts
+++ b/__tests__/unit/categories/js/release-workflow/config/index.spec.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '#src/categories/js/release-workflow/config/index.ts';
 import { expectGithubWorkflow } from '#__tests__/utils/github.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('release-workflow/config', () => {
   it('returns the release workflow content', () => {

--- a/__tests__/unit/categories/js/release-workflow/release-workflow.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/release-workflow/release-workflow.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem } from '#__tests__/setup-test-context.ts';
 import { releaseWorkflow } from '#src/categories/js/release-workflow/release-workflow.entrypoint.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('release-workflow.entrypoint', () => {
   describe('releaseWorkflow', () => {

--- a/__tests__/unit/categories/js/standard-version/config/index.spec.ts
+++ b/__tests__/unit/categories/js/standard-version/config/index.spec.ts
@@ -1,4 +1,5 @@
 import { getConfig } from '#src/categories/js/standard-version/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('standard-version/config', () => {
   it('returns repository-aware changelog link config', () => {

--- a/__tests__/unit/categories/js/standard-version/standard-version.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/standard-version/standard-version.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { standardVersion } from '#src/categories/js/standard-version/standard-version.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('standard-version.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/stylelint/config/index.spec.ts
+++ b/__tests__/unit/categories/js/stylelint/config/index.spec.ts
@@ -1,5 +1,6 @@
 import { presetState } from '#__tests__/setup-test-context.ts';
 import { getConfig } from '#src/categories/js/stylelint/config/index.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('stylelint/config', () => {
   it.each(['default', 'node:ts'] as const)('returns the default stylelint config for %s', (variant) => {

--- a/__tests__/unit/categories/js/stylelint/stylelint.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/stylelint/stylelint.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { presetState, fileSystem, terminal } from '#__tests__/setup-test-context.ts';
 import { stylelint } from '#src/categories/js/stylelint/stylelint.entrypoint.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 
 describe('stylelint.entrypoint', () => {
   beforeEach(() => {

--- a/__tests__/unit/categories/js/stylelint/stylelint.service.spec.ts
+++ b/__tests__/unit/categories/js/stylelint/stylelint.service.spec.ts
@@ -1,6 +1,7 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
 import { prettierMutation, isStylelintInstalled } from '#src/categories/js/stylelint/stylelint.service.ts';
 import type { Config } from '#src/categories/js/stylelint/config/config.interface.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('stylelint.service', () => {
   describe('isStylelintInstalled', () => {

--- a/__tests__/unit/categories/js/test-workflow/config/index.spec.ts
+++ b/__tests__/unit/categories/js/test-workflow/config/index.spec.ts
@@ -1,5 +1,6 @@
 import { getConfig } from '#src/categories/js/test-workflow/config/index.ts';
 import { expectGithubWorkflow } from '#__tests__/utils/github.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('test-workflow/config', () => {
   it('returns the test workflow content', () => {

--- a/__tests__/unit/categories/js/test-workflow/test-workflow.entrypoint.spec.ts
+++ b/__tests__/unit/categories/js/test-workflow/test-workflow.entrypoint.spec.ts
@@ -1,5 +1,6 @@
 import { fileSystem } from '#__tests__/setup-test-context.ts';
 import { testWorkflow } from '#src/categories/js/test-workflow/test-workflow.entrypoint.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('test-workflow.entrypoint', () => {
   describe('testWorkflow', () => {

--- a/__tests__/unit/index.spec.ts
+++ b/__tests__/unit/index.spec.ts
@@ -1,5 +1,6 @@
 import { consoleMock, fileSystem, loading, prompt, terminal } from '#__tests__/setup-test-context.ts';
 import { main } from '#src/index.ts';
+import { describe, expect, it, vi } from 'vitest';
 
 describe('index', () => {
   describe('main', () => {

--- a/__tests__/unit/services/cli.service.spec.ts
+++ b/__tests__/unit/services/cli.service.spec.ts
@@ -1,5 +1,6 @@
 import categories from '#src/categories/index.ts';
 import { installationState, loading, prompt } from '#__tests__/setup-test-context.ts';
+import { describe, expect, it, vi } from 'vitest';
 import {
   chooseMany,
   chooseOne,

--- a/__tests__/unit/services/github.service.spec.ts
+++ b/__tests__/unit/services/github.service.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileSystem } from '#__tests__/setup-test-context.ts';
+import { describe, expect, it } from 'vitest';
 import {
   ensureGithubDir,
   ensureGithubWorkflowsDir,

--- a/__tests__/unit/services/installation.service.spec.ts
+++ b/__tests__/unit/services/installation.service.spec.ts
@@ -1,4 +1,5 @@
 import { fileSystem, installationState } from '#__tests__/setup-test-context.ts';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   createInstalledCheck,
   createRootInstalledCheck,

--- a/__tests__/unit/services/node.service.spec.ts
+++ b/__tests__/unit/services/node.service.spec.ts
@@ -1,5 +1,6 @@
 import { terminal } from '#__tests__/setup-test-context.ts';
 import { getNodeVersion } from '#src/services/node.service.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('node.service', () => {
   describe('getNodeVersion', () => {

--- a/__tests__/unit/services/npm.service.spec.ts
+++ b/__tests__/unit/services/npm.service.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileSystem, terminal } from '#__tests__/setup-test-context.ts';
+import { describe, expect, it } from 'vitest';
 import {
   addNpmScripts,
   installDevDependencies,

--- a/__tests__/unit/services/root.service.spec.ts
+++ b/__tests__/unit/services/root.service.spec.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import { fileSystem } from '#__tests__/setup-test-context.ts';
+import { beforeEach, describe, expect, it } from 'vitest';
 import {
   ensureRootDir,
   existsInRoot,

--- a/__tests__/unit/services/state.service.spec.ts
+++ b/__tests__/unit/services/state.service.spec.ts
@@ -1,4 +1,5 @@
 import { createCategory, createPresetState, jsCategory } from '#src/services/state.service.ts';
+import { afterEach, describe, expect, it } from 'vitest';
 
 describe('state.service', () => {
   describe('jsCategory', () => {

--- a/__tests__/unit/utils/console.utils.spec.ts
+++ b/__tests__/unit/utils/console.utils.spec.ts
@@ -1,4 +1,5 @@
 import { bold } from '#src/utils/console.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('console.utils', () => {
   describe('bold', () => {

--- a/__tests__/unit/utils/mutation.utils.spec.ts
+++ b/__tests__/unit/utils/mutation.utils.spec.ts
@@ -1,5 +1,6 @@
 import { scheduler } from 'node:timers/promises';
 import { applyMutations } from '#src/utils/mutation.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('mutation.utils', () => {
   describe('applyMutations', () => {

--- a/__tests__/unit/utils/string.utils.spec.ts
+++ b/__tests__/unit/utils/string.utils.spec.ts
@@ -1,4 +1,5 @@
 import { toCamelCase, toKebabCase } from '#src/utils/string.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('string.utils', () => {
   describe('toKebabCase', () => {

--- a/__tests__/unit/utils/terminal.utils.spec.ts
+++ b/__tests__/unit/utils/terminal.utils.spec.ts
@@ -1,5 +1,6 @@
 import { terminal } from '#__tests__/setup-test-context.ts';
 import { exec } from '#src/utils/terminal.utils.ts';
+import { describe, expect, it } from 'vitest';
 
 describe('terminal.utils', () => {
   describe('exec', () => {

--- a/__tests__/utils/github.utils.ts
+++ b/__tests__/utils/github.utils.ts
@@ -1,4 +1,5 @@
 import { parse } from 'yaml';
+import { expect, it } from 'vitest';
 
 export const expectGithubWorkflow = (yamlString: string, message = 'is parsed') => {
   it(message, () => {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -16,7 +16,6 @@ export default defineConfig(
     languageOptions: {
       globals: {
         ...globals.node,
-        ...globals.vitest,
       },
       parserOptions: {
         project: true,

--- a/src/categories/js/index.ts
+++ b/src/categories/js/index.ts
@@ -6,7 +6,7 @@ import { lintStaged } from '#src/categories/js/lint-staged/lint-staged.entrypoin
 import { stylelint } from '#src/categories/js/stylelint/stylelint.entrypoint.ts';
 import { prettier } from '#src/categories/js/prettier/prettier.entrypoint.ts';
 import { standardVersion } from '#src/categories/js/standard-version/standard-version.entrypoint.ts';
-import { jestEntrypoint } from '#src/categories/js/jest/jest.entrypoint.ts';
+import { jest } from '#src/categories/js/jest/jest.entrypoint.ts';
 import { docker } from '#src/categories/js/docker/docker.entrypoint.ts';
 import { releaseWorkflow } from '#src/categories/js/release-workflow/release-workflow.entrypoint.ts';
 import { testWorkflow } from '#src/categories/js/test-workflow/test-workflow.entrypoint.ts';
@@ -23,8 +23,7 @@ const options = {
   eslint,
   lintStaged,
   stylelint,
-  // named jestEntrypoint because jest is reserved in the test environment
-  jest: jestEntrypoint,
+  jest,
   docker,
   releaseWorkflow,
   testWorkflow,

--- a/src/categories/js/jest/jest.entrypoint.ts
+++ b/src/categories/js/jest/jest.entrypoint.ts
@@ -3,8 +3,7 @@ import { addNpmScripts, installDevDependencies } from '#src/services/npm.service
 import { getConfig } from '#src/categories/js/jest/config/index.ts';
 import { CONFIG_FILE_NAME } from '#src/categories/js/jest/jest.const.ts';
 
-// named jestEntrypoint because jest is reserved in the test environment
-export const jestEntrypoint = async () => {
+export const jest = async () => {
   const { devDependencies, configFileContent, scripts } = getConfig();
 
   await installDevDependencies(...devDependencies);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -19,7 +19,7 @@
     "noEmit": true,
     "lib": ["ESNext"],
     "rootDir": "./",
-    "types": ["vitest/globals", "node"]
+    "types": ["node"]
   },
   "exclude": ["node_modules", "dist", "coverage"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,6 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
-    globals: true,
     include: ['__tests__/unit/**/*.spec.ts'],
     passWithNoTests: true,
     coverage: {


### PR DESCRIPTION
## Task

- [x] Disable vitest globals https://github.com/allohamora/cli/issues/267
- [x] Rename jestEntrypoint to jest

<!--
Please provide a checkbox list of steps that you have completed for this task.
-->

@coderabbitai summary
