### PR TITLE
Bugfix/wrong-docker-compose-ignore

### DIFF
--- a/__tests__/unit/categories/js/docker/docker.installer.spec.ts
+++ b/__tests__/unit/categories/js/docker/docker.installer.spec.ts
@@ -42,7 +42,7 @@ describe('docker.installer', () => {
           '',
           '.dockerignore',
           'Dockerfile',
-          '.docker-compose.yml',
+          'docker-compose.yml',
           '',
         ].join('\n'),
       );

--- a/__tests__/unit/categories/js/docker/preset/index.spec.ts
+++ b/__tests__/unit/categories/js/docker/preset/index.spec.ts
@@ -34,7 +34,7 @@ describe('docker/preset', () => {
         '',
         '.dockerignore',
         'Dockerfile',
-        '.docker-compose.yml',
+        'docker-compose.yml',
       ].join('\n'),
     );
   });

--- a/src/categories/js/docker/preset/default.preset.ts
+++ b/src/categories/js/docker/preset/default.preset.ts
@@ -31,7 +31,7 @@ export const dockerIgnore = dedent`
 
   ${IGNORE_NAME}
   ${FILE_NAME}
-  .docker-compose.yml
+  docker-compose.yml
 `;
 
 export const defaultPreset = {


### PR DESCRIPTION
## Task

- [x] Closes https://github.com/allohamora/cli/issues/302

<!--
Please provide a checkbox list of steps that you have completed for this task.
-->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the Docker ignore preset to exclude `docker-compose.yml`.
  * Updated generated Docker configurations to use the correct filename.
  * Revised automated checks to reflect the corrected behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
